### PR TITLE
Export $PKG_CONFIG_PATH too

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
       "OPENSSL_BIN_PATH": {
           "val": "#{self.bin}",
           "scope": "global"
+      },
+      "PKG_CONFIG_PATH": {
+          "val": "#{self.lib / 'pkgconfig'}",
+          "scope": "global"
       }
     }
   },


### PR DESCRIPTION
`ocaml-ssl` (https://github.com/savonet/ocaml-ssl) uses `$PKG_CONFIG_PATH` to figure out where the lib and include paths are.